### PR TITLE
Resolve #9: adjust z-index of location icon

### DIFF
--- a/app/javascript/styles/map.scss
+++ b/app/javascript/styles/map.scss
@@ -22,6 +22,7 @@ body {
   outline: none;
   overflow-y: scroll;
   padding: 0 24px;
+  position: absolute;
 
   &__geolocate {
     border: .5px solid #0070CD;


### PR DESCRIPTION
Resolves #9 

I wasn't able to resolve this with z-index, but instead by applying `position: absolute` to `.control-panel`.

This doesn't seem directly related (but it came up while I was testing in different browsers), but I've only been able to get geolocation to work in Chrome. Is this just a known development issue or worth looking further into?