### PR TITLE
Move about-panel outside of mapbox div to allow for text selection

### DIFF
--- a/app/javascript/pages/App.jsx
+++ b/app/javascript/pages/App.jsx
@@ -3,10 +3,10 @@ import Map from './components/map';
 import Header from './components/header';
 
 const App = () => (
-  <div>
+  <>
     <Header />
     <Map />
-  </div>
+  </>
 );
 
 export default App;

--- a/app/javascript/pages/components/about-button.jsx
+++ b/app/javascript/pages/components/about-button.jsx
@@ -1,30 +1,21 @@
 import React from 'react';
-import {Component} from 'react';
-import { Portal } from 'react-portal';
 
-
-export default class AboutButton extends Component {
-  constructor(props) {
-    super(props);
-    this.el = document.createElement('div');
-  }
-
-  toggleAboutPanel(event) {
+const AboutButton = () => {
+  const toggleAboutPanel = () => {
     const aboutPanel = document.getElementsByClassName('about-panel')[0];
     if (aboutPanel.className === 'about-panel about-panel--hidden') {
       aboutPanel.className = 'about-panel';
     } else {
       aboutPanel.className = 'about-panel about-panel--hidden';
     }
-  }
-
-  render() {
-    return (
-      <Portal node={document && document.getElementsByClassName('mapboxgl-ctrl-top-right')[0]}>
-        <button className="about-button"
-                aria-label="About"
-                onClick={this.toggleAboutPanel.bind(this)} />
-      </Portal>
-    );
-  }
-}
+  };
+  return (
+    <button
+      className="about-button"
+      aria-label="About"
+      onClick={toggleAboutPanel}
+      type="button"
+    />
+  );
+};
+export default AboutButton;

--- a/app/javascript/pages/components/about-panel.jsx
+++ b/app/javascript/pages/components/about-panel.jsx
@@ -1,13 +1,7 @@
-import React, { Component } from 'react';
-import { Portal } from 'react-portal';
+import React from 'react';
 
-export default class AboutPanel extends Component {
-  constructor(props) {
-    super(props);
-    this.el = document.createElement('div');
-  }
-
-  toggleText(event) {
+const AboutPanel = () => {
+  const toggleText = (event) => {
     let target;
 
     if (event.target.className.includes('about-panel__heading')) {
@@ -29,96 +23,94 @@ export default class AboutPanel extends Component {
       target.nextSibling.className = 'about-panel__text about-panel__text--hidden';
       target.querySelector('.about-panel__arrow--down').className = 'about-panel__arrow about-panel__arrow--right';
     }
-  }
+  };
 
-  render() {
-    return (
-      <Portal node={document && document.getElementsByClassName('mapboxgl-ctrl-top-right')[0]}>
-        <div className="about-panel about-panel--hidden">
-          <div className="about-panel__object">
-            <button
-              onClick={this.toggleText.bind(this)}
-              className="about-panel__heading about-panel__heading--first"
-              type="button"
-            >
-              <div className="about-panel__arrow about-panel__arrow--right" />
-              About
-            </button>
-            <p className="about-panel__text about-panel__text--hidden">
-              This map is a comprehensive map of pedestrian and bicycle facilities throughout the MAPC region and beyond. The data on this map tool has been collected from a number of sources including city/town trail data, land trusts, DCR, MassDOT, and other sources.
-            </p>
-          </div>
-          <div className="about-panel__object">
-            <button
-              onClick={this.toggleText.bind(this)}
-              className="about-panel__heading"
-              type="button"
-            >
-              <div className="about-panel__arrow about-panel__arrow--right" />
-              Glossary
-            </button>
-            <p className="about-panel__text about-panel__text--hidden">
-              <span className="about-panel__glossary">
-                <strong>Paved Paths </strong>
-                - Hard packed accessible surface, typically asphalt or stonedust
-              </span>
-              <br />
-              <span className="about-panel__glossary">
-                <strong>Unimproved Paths </strong>
-                - Future paved paths, currently with an unimproved natural surface
-              </span>
-              <br />
-              <span className="about-panel__glossary">
-                <strong>Protected Bike Lane </strong>
-                - Physically separated from motor vehicle traffic
-              </span>
-              <br />
-              <span className="about-panel__glossary">
-                <strong>Bike Lane </strong>
-                - Striped lane within the roadway adjacent to traffic
-              </span>
-              <br />
-              <span className="about-panel__glossary">
-                <strong>Paved Footway </strong>
-                - Hard surface path, typically in city park or campus environments
-              </span>
-              <br />
-              <span className="about-panel__glossary">
-                <strong>Natural Surface Footway </strong>
-                - Hiking trail, typically found in conservation areas
-              </span>
-            </p>
-          </div>
-          <div className="about-panel__object">
-            <button
-              onClick={this.toggleText.bind(this)}
-              className="about-panel__heading"
-              type="button"
-            >
-              <div className="about-panel__arrow about-panel__arrow--right" />
-            Disclaimer
-            </button>
-            <p className="about-panel__text about-panel__text--hidden">
-              The data herein is provided for informational purposes only. MAPC makes no warranties, either expressed or implied, and assumes no responsibility for its completeness or accuracy. Users assume all responsibility and risk associated with use of the map and agree to indemnify and hold harmless MAPC with respect to any and all claims and demands that may arise resulting from use of this map.
-            </p>
-          </div>
-          <div className="about-panel__object">
-            <button
-              onClick={this.toggleText.bind(this)}
-              className="about-panel__heading"
-              type="button"
-            >
-              <div className="about-panel__arrow about-panel__arrow--right" />
-              Contribute to this Map
-            </button>
-            <p className="about-panel__text about-panel__text--hidden">
-              We welcome contributions to this map including adding to and editing the data! We have an online editing tool available for you to use. To found out how to access the editing functions, please contact David Loutzenheiser at
-              {' '}
-              <a href="mailto:dloutzenheiser@mapc.org">dloutzenheiser@mapc.org</a>
-            </p>
-          </div>
-        </div>
-      </Portal>
-    );
-  }
-}
+  return (
+    <div className="about-panel about-panel--hidden">
+      <div className="about-panel__object">
+        <button
+          onClick={event => toggleText(event)}
+          className="about-panel__heading"
+          type="button"
+        >
+          <div className="about-panel__arrow about-panel__arrow--right" />
+          About
+        </button>
+        <p className="about-panel__text about-panel__text--hidden">
+          This map is a comprehensive map of pedestrian and bicycle facilities throughout the MAPC region and beyond. The data on this map tool has been collected from a number of sources including city/town trail data, land trusts, DCR, MassDOT, and other sources.
+        </p>
+      </div>
+      <div className="about-panel__object">
+        <button
+          onClick={event => toggleText(event)}
+          className="about-panel__heading"
+          type="button"
+        >
+          <div className="about-panel__arrow about-panel__arrow--right" />
+          Glossary
+        </button>
+        <p className="about-panel__text about-panel__text--hidden">
+          <span className="about-panel__glossary">
+            <strong>Paved Paths </strong>
+            - Hard packed accessible surface, typically asphalt or stonedust
+          </span>
+          <br />
+          <span className="about-panel__glossary">
+            <strong>Unimproved Paths </strong>
+            - Future paved paths, currently with an unimproved natural surface
+          </span>
+          <br />
+          <span className="about-panel__glossary">
+            <strong>Protected Bike Lane </strong>
+            - Physically separated from motor vehicle traffic
+          </span>
+          <br />
+          <span className="about-panel__glossary">
+            <strong>Bike Lane </strong>
+            - Striped lane within the roadway adjacent to traffic
+          </span>
+          <br />
+          <span className="about-panel__glossary">
+            <strong>Paved Footway </strong>
+            - Hard surface path, typically in city park or campus environments
+          </span>
+          <br />
+          <span className="about-panel__glossary">
+            <strong>Natural Surface Footway </strong>
+            - Hiking trail, typically found in conservation areas
+          </span>
+        </p>
+      </div>
+      <div className="about-panel__object">
+        <button
+          onClick={event => toggleText(event)}
+          className="about-panel__heading"
+          type="button"
+        >
+          <div className="about-panel__arrow about-panel__arrow--right" />
+        Disclaimer
+        </button>
+        <p className="about-panel__text about-panel__text--hidden">
+          The data herein is provided for informational purposes only. MAPC makes no warranties, either expressed or implied, and assumes no responsibility for its completeness or accuracy. Users assume all responsibility and risk associated with use of the map and agree to indemnify and hold harmless MAPC with respect to any and all claims and demands that may arise resulting from use of this map.
+        </p>
+      </div>
+      <div className="about-panel__object">
+        <button
+          onClick={event => toggleText(event)}
+          className="about-panel__heading"
+          type="button"
+        >
+          <div className="about-panel__arrow about-panel__arrow--right" />
+          Contribute to this Map
+        </button>
+        <p className="about-panel__text about-panel__text--hidden">
+          We welcome contributions to this map including adding to and editing the data! We have an online editing tool available for you to use. To found out how to access the editing functions, please contact David Loutzenheiser at
+          {' '}
+          <a href="mailto:dloutzenheiser@mapc.org">dloutzenheiser@mapc.org</a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AboutPanel;

--- a/app/javascript/pages/components/map.jsx
+++ b/app/javascript/pages/components/map.jsx
@@ -46,15 +46,10 @@ export default class Map extends Component {
 
   componentDidMount() {
     const mapboxobj = this.mapRef.current.getMap();
-    console.log(mapboxobj)
     mapboxobj.addControl(new mapboxgl.ScaleControl({
       maxWidth: 100,
       unit: 'imperial',
     }), 'bottom-right');
-    console.log(mapboxobj)
-    // mapboxgl.addControl(new MapboxGeocoder({
-    //   region: 'ma',
-    // }));
   }
 
   updateMapLayers(updatedMapStyle) {
@@ -96,21 +91,19 @@ export default class Map extends Component {
   }
 
   handleViewportChange(viewport) {
-    this.setState({
-      viewport: { ...this.state.viewport, ...viewport }
-    });
-  };
+    this.setState(prevState => ({ viewport: { ...prevState.viewport, ...viewport } }));
+  }
 
   render() {
     const currentState = this.state;
     return (
-      <div className="test">
+      <main>
         <div className="cliploader__wrapper">
           <ClipLoader
             css={override}
-            sizeUnit={'px'}
+            sizeUnit="px"
             size={100}
-            color={'rgb(0, 112, 205)'}
+            color="rgb(0, 112, 205)"
             loading={currentState.loading}
             className="cliploader__load"
           />
@@ -157,10 +150,10 @@ export default class Map extends Component {
           <BasemapPanel
             changeBasemap={this.changeBasemap}
           />
-          <AboutButton />
-          <AboutPanel />
         </ReactMapGL>
-      </div>
+        <AboutButton />
+        <AboutPanel />
+      </main>
     );
   }
 }

--- a/app/javascript/styles/map.scss
+++ b/app/javascript/styles/map.scss
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700&display=swap);
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700&display=swap');
 $asset-path: '/assets/images';
 $toggle-switch-height: 20px;
 $control-margin-top: 70px;
@@ -410,13 +410,6 @@ body {
   }
 }
 
-.mapboxgl-ctrl-top-right {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  margin-top: $control-margin-top;
-}
-
 .mapboxgl-ctrl-bottom-right > .mapboxgl-ctrl-scale {
   @media (max-width: 640px) {
     bottom: 0;
@@ -443,6 +436,9 @@ body {
   margin: 0 1rem 0 auto;
   padding: 0;
   pointer-events: auto;
+  position: absolute;
+  right: 0;
+  top: 70px;
   width: 2.5rem;
 }
 
@@ -453,7 +449,9 @@ body {
   margin: 1rem;
   max-width: 19rem;
   outline: none;
+  position: absolute;
   right: 0;
+  top: 108px;
   z-index: 9;
 
   &--hidden {
@@ -471,10 +469,10 @@ body {
     pointer-events: auto;
     text-align: left;
     width: 19rem;
+  }
 
-    &--first {
-      margin-top: .4rem;
-    }
+  &__heading:first-child {
+    margin-top: .4rem;
   }
 
   &__text {


### PR DESCRIPTION
Resolves #40 

* Use absolute positioning to move panel out of normal DOM flow; it was otherwise inheriting a `cursor: grab` CSS rule that made it impossible to select text/click into David’s email address
* Refactor about-button and about-panel into functional components
* Remove extraneous CSS and console.log statements

