### PR TITLE
Add proper attribution to Cali Terrain map

### DIFF
--- a/app/javascript/pages/components/map/cali.json
+++ b/app/javascript/pages/components/map/cali.json
@@ -1,6 +1,6 @@
 {
     "version": 8,
-    "name": "TrailMap Cali Terrain",
+    "name": "Cali Terrain",
     "metadata": {
         "mapbox:autocomposite": true,
         "mapbox:type": "template",
@@ -1354,7 +1354,7 @@
     "created": "2019-09-25T14:00:07.988Z",
     "id": "ck0zc5g2v17c31cpd3c5jg1ye",
     "modified": "2019-09-25T14:23:47.170Z",
-    "owner": "ihill",
+    "owner": "Amy Lee Walton",
     "visibility": "private",
     "draft": false
 }


### PR DESCRIPTION
Resolves #26 

In going back to the [original basemap](https://www.mapbox.com/gallery/#cali-terrain), I noticed that the double attribution is there too. There are two different sources listed in the JSON (mapbox://mapbox.satellite and mapbox://mapbox.terrain-rgb), plus a composite; our other three basemaps only have a single composite source. I think that the "duplicate" attribution is actually just attributing credit to both sources in a very similar format.