### PR TITLE
Att/set panel positioning

### DIFF
--- a/app/javascript/styles/map.scss
+++ b/app/javascript/styles/map.scss
@@ -53,7 +53,7 @@ body {
 
 .basemap-panel {
   @media only screen and (max-width: 600px) {
-    position: unset;
+    left: 0;
   }
   background: #fff;
   border: 1px solid #B7B7B7;
@@ -67,7 +67,8 @@ body {
   max-width: 10rem;
   outline: none;
   padding: 0 24px;
-  position: relative;
+  position: absolute;
+  top: 124px;
 
   &__filter-toggle-button {
     @media only screen and (max-width: 426px) {
@@ -191,6 +192,7 @@ body {
   outline: none;
   overflow-y: scroll;
   position: absolute;
+  top: 124px;
 
   &__geolocate {
     border: .5px solid #0070CD;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Trailmap 3</title>
+    <title>Trailmap</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.0/mapbox-gl.css' rel='stylesheet' />


### PR DESCRIPTION
Position the basemap and control panels absolutely (instead of relative to the geolocate button); when browsers are automatically set to not collect geolocation information, that button doesn't exist, and our panels thus hit the top of the page (and were slightly obscured by the header)

This also fixes the title in partial completion of #36 (we still don't have a favicon)