### PR TITLE
Display all 6 existing trail types on load

### DIFF
--- a/app/javascript/pages/components/control-panel.jsx
+++ b/app/javascript/pages/components/control-panel.jsx
@@ -28,10 +28,6 @@ export default class ControlPanel extends BaseControl {
   }
 
   componentDidMount() {
-    document.querySelector('.filter__button-paved-paths').click();
-    document.querySelector('.filter__button-unimproved-paths').click();
-    document.querySelector('.filter__button-protected-bike-lane').click();
-    document.querySelector('.filter__button-bike-lane').click();
     this.setState({ origScreenWidth: window.screen.availWidth });
   }
 

--- a/app/javascript/pages/components/control-panel/filter-button-container.jsx
+++ b/app/javascript/pages/components/control-panel/filter-button-container.jsx
@@ -14,32 +14,31 @@ function FilterButtonContainer({
   const buttonClasses = `filter__button filter__button-${trailType.replace(/\s+/g, '-').toLowerCase()}`;
 
   return (
-    <div className={`filter filter__${trailType.replace(/\s+/g, '-').toLowerCase()}`} key={trailType}>
+    <div
+      className={`filter filter__${trailType.replace(/\s+/g, '-').toLowerCase()} filter__${trailType.replace(/\s+/g, '-').toLowerCase()}--selected`}
+      key={trailType}
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        toggleEsriLayer(trailType);
+        toggleCSS(trailType);
+      }}
+      onKeyPress={() => {
+        toggleEsriLayer(trailType);
+        toggleCSS(trailType);
+      }}
+    >
       <button
         id={trailType}
         className={buttonClasses}
         type="button"
-        onClick={() => {
-          toggleEsriLayer(trailType);
-          toggleCSS(trailType);
-        }}
       />
-      <span className="filter__label">
+      <span className="filter__label filter__label--selected">
         {trailType}
       </span>
       <div className="filter__slider-container">
         <div
-          className="filter__slider"
-          onClick={() => {
-            toggleEsriLayer(trailType);
-            toggleCSS(trailType);
-          }}
-          onKeyPress={() => {
-            toggleEsriLayer(trailType);
-            toggleCSS(trailType);
-          }}
-          role="button"
-          tabIndex={0}
+          className="filter__slider filter__slider--selected"
         />
       </div>
     </div>

--- a/app/javascript/pages/components/map.jsx
+++ b/app/javascript/pages/components/map.jsx
@@ -23,12 +23,12 @@ export default class Map extends Component {
       },
       opacity: {
         existing: {
-          'Paved Paths': 0,
-          'Unimproved Paths': 0,
-          'Protected Bike Lane': 0,
-          'Bike Lane': 0,
-          'Paved Footway': 0,
-          'Natural Surface Footway': 0,
+          'Paved Paths': 1,
+          'Unimproved Paths': 1,
+          'Protected Bike Lane': 1,
+          'Bike Lane': 1,
+          'Paved Footway': 1,
+          'Natural Surface Footway': 1,
         },
         proposed: {
           'Paved Paths': 0,


### PR DESCRIPTION
After user feedback, David requested on Slack that we set all of the existing trails to display on initial page load (instead of excluding paved footways/natural surface footways). This PR updates that rule with a couple of side effects:
- Load the filter buttons with the `--selected` classes and set their trail opacities to 1 instead of applying a `click` event during `componentDidMount` (toggling the trails off and back on again still works the same)
- Apply the filter button click event to the wrapper `.filter` div so that a user can click on the image, the toggle, or the trail text

On a marginally-related note, could you go into the repo settings and set develop as the base branch?